### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ const PLATFORM: &'static str = "osx";
 const PLATFORM: &'static str = "linux";
 
 fn fetch_from_internet(command: &str) -> String {
-    let common_url = format!("https://raw.github.com/tldr-pages/tldr/master/pages/common/{page}.md", page = command);
-    let platform_url = format!("https://raw.github.com/tldr-pages/tldr/master/pages/{platform}/{page}.md", page = command, platform=PLATFORM);
+    let common_url = format!("https://raw.github.com/tldr-pages/tldr/main/pages/common/{page}.md", page = command);
+    let platform_url = format!("https://raw.github.com/tldr-pages/tldr/main/pages/{platform}/{page}.md", page = command, platform=PLATFORM);
 
     let client = Client::new();
 


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the master branch in favour of the main branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).